### PR TITLE
Add table to 'postcode matches' view

### DIFF
--- a/fhodot/app/ui/src/data_collection_definition.js
+++ b/fhodot/app/ui/src/data_collection_definition.js
@@ -13,6 +13,7 @@ import {
   mismatchesTable,
   osmPostcodeDifferencesTable,
   osmUnmatchedTable,
+  postcodeMatchTable,
 } from "./table_definitions";
 
 // define data sources, layers and associated functions
@@ -54,7 +55,7 @@ const getDataCollection = (inspector) => new DataCollection([
     label: "Postcode matches",
     jsonURL: `api/postcode`,
     markerClickFunction: (data) => inspector.updateOSM(data, true),
-    tables: [],
+    tables: [postcodeMatchTable],
     keyboardShortcut: "p",
   }),
   new DataSource({

--- a/fhodot/app/ui/src/lib/utils.js
+++ b/fhodot/app/ui/src/lib/utils.js
@@ -76,6 +76,16 @@ export const getJOSMAddTagsURL = (fhrsProperties, osmProperties) => {
 };
 
 /**
+ * Return JOSM remote control URL to add fhrs:id tag only
+ */
+export const getJOSMAddFHRSIDTagURL = (osmProperties, fhrsID) => {
+  const { osmType, osmIDByType } = osmProperties;
+  const url = new URL(getJOSMLoadURL(osmType, osmIDByType));
+  url.searchParams.append("addtags", `fhrs:id=${fhrsID}`);
+  return url.toString();
+};
+
+/**
  * Open JOSM URL using fetch and return promise
  *
  * This is preferred over a simple link because it avoids navigating

--- a/fhodot/app/ui/src/styles.css
+++ b/fhodot/app/ui/src/styles.css
@@ -264,6 +264,13 @@ td.matched {
 td.unmatched {
   background-color: rgba(0, 203, 255, 0.1);
 }
+td > p {
+  margin: 0px;
+}
+#postcode-matches tbody tr {
+  background-color: rgb(255, 255, 255);
+  border: 1px solid rgb(180, 180, 180);
+}
 
 /* FOOTER */
 footer > p {

--- a/fhodot/app/ui/src/table_definitions.js
+++ b/fhodot/app/ui/src/table_definitions.js
@@ -13,6 +13,8 @@ import {
   getJOSMLoadURL,
   getIDEditURL,
   openJOSMURL,
+  getJOSMAddFHRSIDTagURL,
+  bindJOSMAction,
 } from "./lib/utils";
 
 export const tableGroup = new TableGroup("tables");
@@ -401,7 +403,15 @@ const postcodeMatchTable = new Table({
     their postcode matches the relevant OSM object.`,
   emptyTableMsg: `No unmatched OSM objects with postcodes matching unmatched
     FHRS establishments found on map`,
-  definition: new Map(), // not required, insertRowForFeature redefined below
+  definition: new Map([
+    ["OSM <code>name</code>", null],
+    ["Postcode", null],
+    ["Edit", null],
+    ["On map above", null],
+    ["FHRS establishment name", null],
+    ["FHRS ID", null],
+    ["", null],
+  ]), // fields not required: insertRowForFeature redefined below
   getProperties: (data) => data.features,
 });
 
@@ -415,7 +425,6 @@ postcodeMatchTable.insertRowForFeature = (feature, tableBody) => {
     getValueOrPlaceholder(name), getOSMURL(osmType, osmIDByType),
   );
   const nameCell = createElementWith("td", nameLink);
-  nameCell.className = getFeatureStatus(feature);
   const postcodeCell = createElementWith(
     "td", getValueOrPlaceholder(postcode),
   );
@@ -429,6 +438,7 @@ postcodeMatchTable.insertRowForFeature = (feature, tableBody) => {
       [nameCell, postcodeCell, editActionsCell, mapActionsCell]
         .forEach((osmCell) => {
           osmCell.setAttribute("rowspan", postcodeMatches.length);
+          osmCell.className = getFeatureStatus(feature); // eslint-disable-line no-param-reassign
           row.append(osmCell);
         });
     }
@@ -437,6 +447,14 @@ postcodeMatchTable.insertRowForFeature = (feature, tableBody) => {
       getFSAURL(postcodeMatch.fhrsID),
     );
     row.insertCell().innerHTML = getValueOrPlaceholder(postcodeMatch.fhrsID);
+    const JOSMPara = createElementWith(
+      "p", "Add <code>fhrs:id</code> in JOSM", "action",
+    );
+    row.insertCell().append(JOSMPara);
+    bindJOSMAction(
+      getJOSMAddFHRSIDTagURL(feature.properties, postcodeMatch.fhrsID),
+      JOSMPara,
+    );
     firstRowForFeature = false;
   });
 };

--- a/fhodot/app/ui/src/table_definitions.js
+++ b/fhodot/app/ui/src/table_definitions.js
@@ -385,3 +385,60 @@ export const fhrsNoLocationTable = new Table({
       .map(getFHRSNoLocationRow)
   ),
 });
+
+/**
+ * Table of postcode matches
+ */
+const postcodeMatchTable = new Table({
+  tableGroup,
+  elementID: "postcode-matches",
+  heading: `Unmatched OSM objects with postcodes matching unmatched FHRS
+    establishments`,
+  preTableMsg: `The following OSM objects either have no <code>fhrs:id</code>
+    tag or the <code>fhrs:id</code> does not match an establishment in the
+    current FSA data. The FHRS establishments listed alongside have not been
+    successfully matched to OSM objects using a valid <code>fhrs:id</code> but
+    their postcode matches the relevant OSM object.`,
+  emptyTableMsg: `No unmatched OSM objects with postcodes matching unmatched
+    FHRS establishments found on map`,
+  definition: new Map(), // not required, insertRowForFeature redefined below
+  getProperties: (data) => data.features,
+});
+
+// redefine standard Table.insertRowForFeature method
+postcodeMatchTable.insertRowForFeature = (feature, tableBody) => {
+  const {
+    osmType, osmIDByType, name, postcode, postcodeMatches,
+  } = feature.properties;
+
+  const nameLink = getLink(
+    getValueOrPlaceholder(name), getOSMURL(osmType, osmIDByType),
+  );
+  const nameCell = createElementWith("td", nameLink);
+  nameCell.className = getFeatureStatus(feature);
+  const postcodeCell = createElementWith(
+    "td", getValueOrPlaceholder(postcode),
+  );
+  const editActionsCell = getEditActionsCell(osmType, osmIDByType);
+  const mapActionsCell = getMapActionsCell(feature);
+
+  let firstRowForFeature = true;
+  postcodeMatches.forEach((postcodeMatch) => {
+    const row = tableBody.insertRow();
+    if (firstRowForFeature) {
+      [nameCell, postcodeCell, editActionsCell, mapActionsCell]
+        .forEach((osmCell) => {
+          osmCell.setAttribute("rowspan", postcodeMatches.length);
+          row.append(osmCell);
+        });
+    }
+    row.insertCell().innerHTML = getLink(
+      getValueOrPlaceholder(postcodeMatch.name),
+      getFSAURL(postcodeMatch.fhrsID),
+    );
+    row.insertCell().innerHTML = getValueOrPlaceholder(postcodeMatch.fhrsID);
+    firstRowForFeature = false;
+  });
+};
+
+export { postcodeMatchTable };


### PR DESCRIPTION
Work in progress for issue https://github.com/gregrs-uk/fhodot/issues/8.

Mostly done but needs an extra column with a JOSM link to add the relevant FHRS data to the relevant OSM object. See [getJOSMAddTagsURL](https://github.com/gregrs-uk/fhodot/blob/c7948cfbaf3db8c3738a3701873dd867585fb280/fhodot/app/ui/src/lib/utils.js#L50) helper.

Also needs header row adding.

May need to add parsedAddresses to feature properties returned by endpoint. (See what already happens when using 'Link with FHRS establishment' link in inspector, for example.)