### PR TITLE
#35 Initial updates to docker files to newer versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       POSTGRES_PASSWORD: db
       POSTGRES_DB: gregrs_fhodot
   redis:
-    image: redis:7.0.15-bookworm
+    image: redis:8.0.2-bookworm
   imposm:
     environment:
       PGHOST: postgis

--- a/docker/Dockerfile-imposm
+++ b/docker/Dockerfile-imposm
@@ -1,11 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.17.6
+FROM golang:1.24.4
 RUN apt-get update && apt-get install -y libleveldb-dev libgeos-dev
 WORKDIR /go
-RUN go get github.com/omniscale/imposm3
 RUN go install github.com/omniscale/imposm3/cmd/imposm@v0.11.1
 
-FROM debian:12.7-slim
+FROM debian:13.4-slim
 RUN apt-get update && apt-get install -y libleveldb-dev libgeos-dev postgresql-client
 COPY --from=0 /go/bin/imposm /imposm/imposm
 WORKDIR /fhodot

--- a/docker/Dockerfile-node
+++ b/docker/Dockerfile-node
@@ -1,3 +1,3 @@
-FROM node:20.17.0-bookworm
+FROM node:22.22.2-bookworm
 
 RUN apt-get update && apt-get install -y chromium

--- a/docker/Dockerfile-python
+++ b/docker/Dockerfile-python
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-bookworm
+FROM python:3.13.5-bookworm
 
 WORKDIR /fhodot
 

--- a/docker/Dockerfile-rstats
+++ b/docker/Dockerfile-rstats
@@ -1,15 +1,16 @@
 # syntax=docker/dockerfile:1
 
-FROM r-base:4.2.2
+FROM r-base:4.5.0
 
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev libpq-dev pandoc
 
 RUN R -e 'install.packages("remotes", repos = c(CRAN = "https://cloud.r-project.org"))'
-RUN R -e 'remotes::install_version("renv", "1.0.3")'
+RUN R -e 'remotes::install_version("renv", "1.2.2")'
 
 WORKDIR /fhodot/stats
 COPY stats/renv.lock renv.lock
 ENV RENV_PATHS_LIBRARY /renv-library # outside /fhodot bind mount
+RUN R -e 'renv::upgrade()'
 RUN R -e 'renv::restore()'
 
 CMD [ "R", "-q" , "-e", "targets::tar_make(reporter='silent')"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ click==8.1.7
 click-plugins==1.1.1
 cligj==0.7.2
 coverage==5.2
-Cython==0.29.22
-Fiona==1.9.4.post1
+Cython==3.2.4
+Fiona==1.10.1
 Flask==1.1.2
 Flask-Limiter==1.4
 fuzzywuzzy==0.18.0
@@ -19,11 +19,11 @@ isort==4.3.21
 itsdangerous==1.1.0
 Jinja2==2.11.3
 lazy-object-proxy==1.4.3
-limits==1.5.1
-MarkupSafe==1.1.1
+limits==5.8.0
+MarkupSafe==3.0.3
 mccabe==0.6.1
 munch==2.5.0
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.12
 pylint==2.5.3
 python-Levenshtein==0.12.2
 redis==3.5.3
@@ -31,7 +31,7 @@ requests==2.27.1
 retrying==1.3.3
 Shapely==1.7.1
 six==1.15.0
-SQLAlchemy==1.3.18
+SQLAlchemy==2.0.49
 toml==0.10.1
 Unidecode==1.1.1
 urllib3==1.26.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ mccabe==0.6.1
 munch==2.5.0
 psycopg2-binary==2.9.12
 pylint==2.5.3
-python-Levenshtein==0.12.2
+python-Levenshtein==0.27.3
 redis==3.5.3
 requests==2.27.1
 retrying==1.3.3
 Shapely==1.7.1
 six==1.15.0
-SQLAlchemy==2.0.49
+SQLAlchemy==1.4.54
 toml==0.10.1
 Unidecode==1.1.1
 urllib3==1.26.8

--- a/stats/renv.lock
+++ b/stats/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.2",
+    "Version": "4.5.0",
     "Repositories": [
       {
         "Name": "CRAN",


### PR DESCRIPTION
This uses the versions suggested in the ticket where possible.

Regarding the Go package install of imposm "go install" should be used instead of "go get" as per https://go.dev/doc/go-get-install-deprecation